### PR TITLE
fix: proxy for endpoint api/show

### DIFF
--- a/main.go
+++ b/main.go
@@ -118,7 +118,7 @@ func main() {
 			return
 		}
 
-		modelName := request["name"]
+		modelName := request["model"]
 		if modelName == "" {
 			c.JSON(http.StatusBadRequest, gin.H{"error": "Model name is required"})
 			return


### PR DESCRIPTION
Parameter of POST /api/show is "model" not "name" according to the latest ollama api reference